### PR TITLE
Add QMK Firmware version 0.32.8 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Deployed to GCP via Cloud Build. The `cloudbuild.yaml` builds and pushes a Docke
 
 ### QMK Firmware Versions
 
-The Docker image ships multiple QMK versions under `/root/versions/<version>/` (currently 0.22.14 and 0.28.3). Each firmware/project specifies its target version. Keyboard source files are written into the version-specific `keyboards/` directory, compiled, then cleaned up.
+The Docker image ships multiple QMK versions under `/root/versions/<version>/` (currently 0.22.14, 0.28.3, and 0.32.8). Each firmware/project specifies its target version. Keyboard source files are written into the version-specific `keyboards/` directory, compiled, then cleaned up.
 
 ### Firestore Schema
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ RUN qmk setup --yes --home /root/versions/0.28.3 --branch 0.28.3
 RUN rm -rf /root/versions/0.28.3/keyboards/*
 RUN echo "{}" > /root/versions/0.28.3/data/mappings/keyboard_aliases.hjson
 
+RUN mkdir -p /root/versions/0.32.8
+RUN qmk setup --yes --home /root/versions/0.32.8 --branch 0.32.8
+RUN rm -rf /root/versions/0.32.8/keyboards/*
+RUN echo "{}" > /root/versions/0.32.8/data/mappings/keyboard_aliases.hjson
+
 COPY go.* ./
 RUN go mod download
 COPY ./main.go ./


### PR DESCRIPTION
## Summary
- Add QMK Firmware 0.32.8 setup to Dockerfile (setup, clean keyboards, reset aliases)
- Update CLAUDE.md to reflect the newly supported QMK version

## Test plan
- [x] Verify Docker image builds successfully with the new QMK 0.32.8 version
- [x] Confirm a build task with `qmkFirmwareVersion: "0.32.8"` compiles firmware correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)